### PR TITLE
Add constraint on upper version of Goblint

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -30,7 +30,7 @@
  (depends
   (ocaml (>= 4.13))
   (lintcstubs-gen (= :version))
-  (goblint (>= 2.1.0))
+  (goblint (and (>= 2.1.0) (< 2.2)))
   goblint-cil
   dune-compiledb
   fpath

--- a/lintcstubs.opam
+++ b/lintcstubs.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.13"}
   "lintcstubs-gen" {= version}
-  "goblint" {>= "2.1.0"}
+  "goblint" {>= "2.1.0" & < "2.2"}
   "goblint-cil"
   "dune-compiledb"
   "fpath"


### PR DESCRIPTION
Goblint 2.2 removed `Prelude.Ana` (and all of `Prelude`) thus compilation fails with that version.

opam-repository already applied the constraint in the package: https://github.com/ocaml/opam-repository/pull/24423